### PR TITLE
Swathi, Bindu | BAH-648 | Changing ResponseBody for AppsController

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>org.ict4h</groupId>
             <artifactId>atomfeed-client</artifactId>
-            <version>1.9.4-SNAPSHOT</version>
+            <version>1.9.4</version>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>
@@ -124,7 +124,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>rpm-maven-plugin</artifactId>
-                <version>2.1.5</version>
+                <version>2.2.0</version>
                 <executions>
                     <execution>
                         <id>generate-rpm</id>
@@ -206,6 +206,10 @@
 
 
     <repositories>
+        <repository>
+            <id>ICT4H-releases</id>
+            <url>https://oss.sonatype.org/content/repositories/releases</url>
+        </repository>
         <repository>
             <id>spring-releases</id>
             <url>https://repo.spring.io/libs-release</url>

--- a/src/main/java/org/ict4h/controllers/AppController.java
+++ b/src/main/java/org/ict4h/controllers/AppController.java
@@ -1,11 +1,11 @@
 package org.ict4h.controllers;
 
-import org.ict4h.domain.configuration.AppConfigs;
 import org.ict4h.service.AppConfiguration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
+import java.util.List;
 
 @Controller
 public class AppController {
@@ -17,5 +17,5 @@ public class AppController {
 
     @RequestMapping("/apps")
     @ResponseBody
-    public AppConfigs getAppDetails() {return appConfiguration.getAppConfigs();}
+    public List<String> getAppDetails() {return appConfiguration.getAppNames();}
 }

--- a/src/main/java/org/ict4h/service/AppConfiguration.java
+++ b/src/main/java/org/ict4h/service/AppConfiguration.java
@@ -5,6 +5,9 @@ import org.ict4h.domain.configuration.AppConfigs;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Component
 @ConfigurationProperties
 public class AppConfiguration {
@@ -12,6 +15,14 @@ public class AppConfiguration {
 
     public AppConfigs getAppConfigs() {
         return appConfigs;
+    }
+
+    public List<String> getAppNames() {
+        List<String> appNames = new ArrayList<>();
+        for (AppConfig appConfig : appConfigs) {
+            appNames.add(appConfig.getAppName());
+        }
+        return appNames;
     }
 
     public AppConfig getAppConfigForApp(String appName) {

--- a/src/main/resources/static/views/homepage.html
+++ b/src/main/resources/static/views/homepage.html
@@ -2,7 +2,7 @@
     <div class="app-container" ng-repeat="result in results">
         <div class="app">
             <a href="#/apps/{{result.appName}}/feedStatus">
-                <h3>{{result.appName}}</h3>
+                <h3>{{result}}</h3>
                 <label>Get Feed Status</label>
             </a>
         </div>

--- a/src/test/java/org/ict4h/controller/AppStatusControllerTest.java
+++ b/src/test/java/org/ict4h/controller/AppStatusControllerTest.java
@@ -11,6 +11,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
+import java.util.List;
+
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.*;
@@ -25,9 +27,9 @@ public class AppStatusControllerTest {
     @Value("${../../resources/application.yml}")
     @Test
     public void shouldRetrieveConfig() {
-        AppConfigs appDetails = appController.getAppDetails();
+        List<String> appDetails = appController.getAppDetails();
         assertThat(appDetails.size(), is((equalTo(1))));
-        AppConfig appConfig = appDetails.get(0);
-        assertThat(appConfig.getAppName(), is(equalTo("testApp")));
+        String appConfig = appDetails.get(0);
+        assertThat(appConfig, is(equalTo("testApp")));
     }
 }


### PR DESCRIPTION
We have observed the below issues with /atomfeed-console/apps api :
# unnecessarily exposing credentials of all databases.

{code:java}
[{"appName":"OpenMRS","dbUrl":"jdbc:mysql://127.0.0.1:3306/openmrs","dbUser":"****","dbPassword":"****"},{"appName":"OpenERP","dbUrl":"jdbc:postgresql://127.0.0.1:5432/openerp","dbUser":"****","dbPassword":null},{"appName":"OpenELIS","dbUrl":"jdbc:postgresql://127.0.0.1:5432/clinlims?currentSchema=clinlims","dbUser":"****","dbPassword":null},{"appName":"Pacs Integration","dbUrl":"jdbc:postgresql://127.0.0.1:5432/bahmni_pacs","dbUser":"****","dbPassword":null}]
{code}

# exposed without any authentication

This is a critical issues needs to be fixed ASAP.
For now we went ahead and stopped atomfeed-console service in all our qa, demo environments.
We need to communicate this to Bahmni Implementations and suggest the hack of stopping atomfeed-console for now see how to go about mitigating the issue.


*Tech*
1. AppController - change the method to return only array of objects containing “appName” 
{code:json}
[{“appName”:“OpenMRS”},{“appName”:“OpenERP”},{“appName”:“OpenELIS”},{“appName”:“Pacs Integration”}]
{code}
2. HomePageCtrl.js - remove the console.log() statement

Bahmni JIRA card link -> https://bahmni.atlassian.net/browse/BAH-648